### PR TITLE
Bumper check on perioutstop

### DIFF
--- a/ardumower/robot.cpp
+++ b/ardumower/robot.cpp
@@ -4394,12 +4394,20 @@ void Robot::checkBumpers() {
       motorLeftRpmCurr = motorRightRpmCurr = 0 ;
       motorLeftPWMCurr = motorRightPWMCurr = 0;
       setMotorPWM( 0, 0, false );
-      if (bumperLeft) {
-        ShowMessageln("Bumper left trigger");
-        reverseOrBidir(LEFT);
-      } else {
-        ShowMessageln("Bumper right trigger");
+      if (stateCurr == STATE_PERI_OUT_STOP)
+      {
+        odometryRight = stateEndOdometryRight + 1 odometryLeft = stateEndOdometryLeft + 1
+      }
+      else
+      {
+        if (bumperLeft)
+        {
+          Console.println("Bumper left trigger");
+          reverseOrBidir(LEFT);
+        } else {
+        Console.println("Bumper right trigger");
         reverseOrBidir(RIGHT);
+      }
       }
     }
 
@@ -5753,6 +5761,7 @@ void Robot::loop()  {
 
     case STATE_PERI_OUT_STOP:
       motorControlOdo();
+      checkBumpers();
       if (((odometryRight >= stateEndOdometryRight) && (odometryLeft >= stateEndOdometryLeft)))
         if (motorLeftPWMCurr == 0 && motorRightPWMCurr == 0)  { //wait until the 2 motors completly stop because rotation is inverted
           setNextState(STATE_PERI_OUT_REV, rollDir);

--- a/ardumower/robot.cpp
+++ b/ardumower/robot.cpp
@@ -4403,11 +4403,11 @@ void Robot::checkBumpers() {
       {
         if (bumperLeft)
         {
-          Console.println("Bumper left trigger");
+          ShowMessageln("Bumper left trigger");
           reverseOrBidir(LEFT);
         } else {
-        Console.println("Bumper right trigger");
-        reverseOrBidir(RIGHT);
+          ShowMessageln("Bumper right trigger");
+          reverseOrBidir(RIGHT);
       }
       }
     }

--- a/ardumower/robot.cpp
+++ b/ardumower/robot.cpp
@@ -4396,7 +4396,8 @@ void Robot::checkBumpers() {
       setMotorPWM( 0, 0, false );
       if (stateCurr == STATE_PERI_OUT_STOP)
       {
-        odometryRight = stateEndOdometryRight + 1 odometryLeft = stateEndOdometryLeft + 1
+        odometryRight = stateEndOdometryRight + 1;
+        odometryLeft = stateEndOdometryLeft + 1;
       }
       else
       {

--- a/ardumower/robot.cpp
+++ b/ardumower/robot.cpp
@@ -4396,8 +4396,8 @@ void Robot::checkBumpers() {
       setMotorPWM( 0, 0, false );
       if (stateCurr == STATE_PERI_OUT_STOP)
       {
-        odometryRight = stateEndOdometryRight + 1;
-        odometryLeft = stateEndOdometryLeft + 1;
+        odometryRight = stateEndOdometryRight;
+        odometryLeft = stateEndOdometryLeft;
       }
       else
       {


### PR DESCRIPTION
If slowing down in STATE_PERI_OUT_STOP and the bumpers are triggered, the rover wouldn't notice.

This PR fixes this. When bumpers trigger in state STATE_PERI_OUT_STOP the rover immediately stops.
This is the same behaviour as it would be when in STATE_FORWARD_ODO